### PR TITLE
Fix go.mod module path to match repository owner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jenting/argocd-watcher
+module github.com/hsiaoairplane/argocd-watcher
 
 go 1.26.0
 


### PR DESCRIPTION
Change module path from github.com/jenting/argocd-watcher to github.com/hsiaoairplane/argocd-watcher so it matches the actual repository location.