### PR TITLE
CI: align Go matrix with go.mod (1.26 only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,15 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.21'
-          - '1.22'
-          - '1.23'
-          - '1.24'
-          - '1.25'
           - '1.26'
 
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
go.mod requires `go 1.26.0`, so the 1.21-1.25 matrix entries always failed. Trim the matrix to 1.26 and bump checkout/setup-go to v4/v5 to match the docker workflow.