### PR TITLE
Replace RetryWatcher with dynamic informer

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,13 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
-	toolsWatch "k8s.io/client-go/tools/watch"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/go-redis/redis/v7"
@@ -24,6 +22,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
+
+// keyTTL is the expiration applied to every Redis key. The informer resync
+// period must stay shorter than this so that unchanged applications are
+// re-written before their key expires.
+const keyTTL = time.Hour
 
 var (
 	appEvents = prometheus.NewCounterVec(
@@ -39,6 +42,67 @@ func init() {
 	prometheus.MustRegister(appEvents)
 }
 
+// appKey builds the Redis key for an application: "<spec.project>|<name>".
+// A missing spec.project yields an empty project segment; only a type
+// mismatch is reported as an error.
+func appKey(obj *unstructured.Unstructured) (string, error) {
+	project, _, err := unstructured.NestedString(obj.Object, "spec", "project")
+	if err != nil {
+		return "", fmt.Errorf("getting spec.project: %w", err)
+	}
+	return fmt.Sprintf("%s|%s", project, obj.GetName()), nil
+}
+
+// upsertApp writes the application to Redis under its app key. The object is
+// deep-copied before the managedFields are stripped so that the shared
+// informer cache is never mutated.
+func upsertApp(rdb *redis.Client, obj *unstructured.Unstructured) error {
+	obj = obj.DeepCopy()
+	unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
+
+	key, err := appKey(obj)
+	if err != nil {
+		return err
+	}
+
+	val, err := json.Marshal(obj.Object)
+	if err != nil {
+		return fmt.Errorf("marshaling application %q: %w", key, err)
+	}
+
+	if err := rdb.Set(key, val, keyTTL).Err(); err != nil {
+		return fmt.Errorf("setting key %q: %w", key, err)
+	}
+	return nil
+}
+
+// deleteApp removes the application's key from Redis.
+func deleteApp(rdb *redis.Client, obj *unstructured.Unstructured) error {
+	key, err := appKey(obj)
+	if err != nil {
+		return err
+	}
+	if err := rdb.Del(key).Err(); err != nil {
+		return fmt.Errorf("deleting key %q: %w", key, err)
+	}
+	return nil
+}
+
+// toUnstructured extracts an *unstructured.Unstructured from an informer event
+// object, transparently unwrapping the tombstone delivered for deletions that
+// were missed while the watch was disconnected.
+func toUnstructured(obj interface{}) (*unstructured.Unstructured, bool) {
+	switch o := obj.(type) {
+	case *unstructured.Unstructured:
+		return o, true
+	case cache.DeletedFinalStateUnknown:
+		u, ok := o.Obj.(*unstructured.Unstructured)
+		return u, ok
+	default:
+		return nil, false
+	}
+}
+
 func main() {
 	// Define flags for configuration
 	redisAddr := flag.String("redis-addr", "localhost:16379", "Redis server address")
@@ -46,6 +110,8 @@ func main() {
 	argocdNamespace := flag.String("argocd-namespace", "argocd", "ArgoCD namespace")
 	metricsPort := flag.String("metrics-port", "8080", "Metrics server port")
 	logLevel := flag.String("log-level", "info", "Log level (trace, debug, info, warn, error)")
+	resyncPeriod := flag.Duration("resync-period", 30*time.Minute,
+		"Informer resync period; must be shorter than the 1h Redis key TTL so keys stay refreshed")
 
 	// Parse command-line flags
 	flag.Parse()
@@ -60,8 +126,7 @@ func main() {
 
 	namespace := *argocdNamespace
 
-	// Handle termination signals and propagate cancellation to the API
-	// server List/Watch calls below.
+	// Handle termination signals and propagate cancellation to the informer.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	defer stop()
 
@@ -97,112 +162,60 @@ func main() {
 		Resource: "applications",
 	}
 
-	appList, err := dynamicClient.Resource(resource).Namespace(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		log.Fatal(err)
-	}
+	// A dynamic shared informer handles the initial list, automatically
+	// re-lists when the resource version expires (instead of failing with a
+	// "too old resource version" error like a bare RetryWatcher), and
+	// re-delivers every object once per resync period so the Redis key TTL is
+	// kept fresh for applications that never change.
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, *resyncPeriod, namespace, nil)
+	informer := factory.ForResource(resource).Informer()
 
-	for _, item := range appList.Items {
-		// Remove the metadata.managedFields field
-		unstructured.RemoveNestedField(item.Object, "metadata", "managedFields")
-
-		specProject, _, err := unstructured.NestedString(item.Object, "spec", "project")
-		if err != nil {
-			log.Errorf("Error getting spec.project: %v", err)
-			continue
-		}
-
-		// Set the key-value pair
-		key := fmt.Sprintf("%s|%s", specProject, item.GetName())
-		val, _ := json.Marshal(item.Object)
-
-		err = rdb.Set(key, val, time.Hour).Err()
-		if err != nil {
-			log.Errorf("Failed to set key %q: %v", key, err)
-			continue
-		}
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			u, ok := toUnstructured(obj)
+			if !ok {
+				log.Errorln("Add: failed to cast event object to Unstructured")
+				return
+			}
+			appEvents.WithLabelValues("ADDED").Inc()
+			if err := upsertApp(rdb, u); err != nil {
+				log.Errorf("Add: %v", err)
+			}
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			u, ok := toUnstructured(newObj)
+			if !ok {
+				log.Errorln("Update: failed to cast event object to Unstructured")
+				return
+			}
+			appEvents.WithLabelValues("MODIFIED").Inc()
+			if err := upsertApp(rdb, u); err != nil {
+				log.Errorf("Update: %v", err)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			u, ok := toUnstructured(obj)
+			if !ok {
+				log.Errorln("Delete: failed to cast event object to Unstructured")
+				return
+			}
+			appEvents.WithLabelValues("DELETED").Inc()
+			if err := deleteApp(rdb, u); err != nil {
+				log.Errorf("Delete: %v", err)
+			}
+		},
+	}); err != nil {
+		log.Fatalf("Failed to add event handler: %v", err)
 	}
 
 	log.Infoln("Starting watcher...")
+	factory.Start(ctx.Done())
 
-	initRV := appList.GetResourceVersion()
-	retryWatcher, err := toolsWatch.NewRetryWatcher(initRV, &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			// Use the ResourceVersion supplied by RetryWatcher so that a
-			// reconnect resumes from the last observed version instead of
-			// restarting from initRV (which eventually triggers a
-			// "too old resource version" error).
-			options.Watch = true
-			return dynamicClient.Resource(resource).Namespace(namespace).Watch(ctx, options)
-		},
-	})
-	if err != nil {
-		log.Fatalf("Failed to create retry watcher: %v", err)
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		log.Fatalln("Failed to sync informer cache")
 	}
-	defer retryWatcher.Stop()
+	log.Infoln("Informer cache synced")
 
-	for {
-		select {
-		case event := <-retryWatcher.ResultChan():
-			obj, ok := event.Object.(*unstructured.Unstructured)
-			if !ok {
-				log.Errorln("Failed to cast event object to Unstructured")
-				continue
-			}
-
-			appEvents.WithLabelValues(string(event.Type)).Inc()
-
-			switch event.Type {
-			case watch.Added, watch.Modified:
-				log.Debugf("Application added/modified: %v", event.Object)
-
-				// Remove the metadata.managedFields field
-				unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
-
-				// Print spec.project
-				specProject, _, err := unstructured.NestedString(obj.Object, "spec", "project")
-				if err != nil {
-					log.Errorf("Error getting spec.project: %v", err)
-					continue
-				}
-
-				// Set and Get a key-value pair
-				key := fmt.Sprintf("%s|%s", specProject, obj.GetName())
-				val, _ := json.Marshal(event.Object)
-
-				err = rdb.Set(key, val, time.Hour).Err()
-				if err != nil {
-					log.Errorf("Failed to set key %q: %v", key, err)
-					continue
-				}
-
-			case watch.Deleted:
-				log.Debugf("Application deleted: %v", event.Object)
-
-				specProject, _, err := unstructured.NestedString(obj.Object, "spec", "project")
-				if err != nil {
-					log.Errorf("Error getting spec.project: %v", err)
-					continue
-				}
-				log.Debugf("spec.project: %s", specProject)
-
-				// Set and Get a key-value pair
-				key := fmt.Sprintf("%s|%s", specProject, obj.GetName())
-				err = rdb.Del(key).Err()
-				if err != nil {
-					log.Errorf("Failed to delete key %q: %v", key, err)
-					continue
-				}
-
-			case watch.Error:
-				log.Errorf("Watch error event: %v", event.Object)
-
-			case watch.Bookmark:
-			default:
-			}
-		case <-ctx.Done():
-			log.Infoln("Shutting down watcher...")
-			return
-		}
-	}
+	<-ctx.Done()
+	log.Infoln("Shutting down watcher...")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestAppKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "project and name present",
+			obj: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "my-app"},
+				"spec":     map[string]interface{}{"project": "my-proj"},
+			},
+			want: "my-proj|my-app",
+		},
+		{
+			name: "missing project yields empty project segment",
+			obj: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "my-app"},
+			},
+			want: "|my-app",
+		},
+		{
+			name: "wrong type for project returns error",
+			obj: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "my-app"},
+				"spec":     map[string]interface{}{"project": 123},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &unstructured.Unstructured{Object: tt.obj}
+			got, err := appKey(u)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("appKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToUnstructured(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{"kind": "Application"}}
+
+	t.Run("plain object", func(t *testing.T) {
+		got, ok := toUnstructured(u)
+		if !ok || got != u {
+			t.Fatalf("toUnstructured(u) = %v, %v; want %v, true", got, ok, u)
+		}
+	})
+
+	t.Run("tombstone", func(t *testing.T) {
+		tombstone := cache.DeletedFinalStateUnknown{Key: "argocd/my-app", Obj: u}
+		got, ok := toUnstructured(tombstone)
+		if !ok || got != u {
+			t.Fatalf("toUnstructured(tombstone) = %v, %v; want %v, true", got, ok, u)
+		}
+	})
+
+	t.Run("unexpected type", func(t *testing.T) {
+		if _, ok := toUnstructured("not-an-object"); ok {
+			t.Fatalf("toUnstructured(string) ok = true; want false")
+		}
+	})
+}


### PR DESCRIPTION
## What

Switch the ArgoCD application watcher from a bare `RetryWatcher` to a **dynamic shared informer**, and fix related correctness issues.

## Why

- **`RetryWatcher` does not re-list on expired resource version.** When the resource version becomes too old (`410 Gone`), a bare retry watcher can get stuck / error out. An informer re-lists automatically.
- **Keys silently disappeared from Redis.** Keys carry a 1h TTL but were only refreshed on watch events, so an application that never changed had its cache entry expire after 1h. The informer re-delivers every object once per resync period, keeping the TTL fresh.
- **`json.Marshal` errors were swallowed** (`val, _ := json.Marshal(...)`), risking bad data written to Redis.

## Changes

- Replace the manual `List` + `RetryWatcher` loop with `dynamicinformer.NewFilteredDynamicSharedInformerFactory`.
- Add `--resync-period` flag (default **30m**, kept shorter than the 1h key TTL).
- Handle `json.Marshal` errors instead of ignoring them.
- Deep-copy objects before stripping `managedFields` so the shared informer cache is not mutated.
- Unwrap `DeletedFinalStateUnknown` tombstones on deletion so deletes missed during a disconnect still clear the Redis key.
- Extract `appKey` / `upsertApp` / `deleteApp` / `toUnstructured` and add unit tests (`main_test.go`) — the repo previously had no tests.

## Testing

`go build`, `go vet`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)